### PR TITLE
ヘッダーレスデザインへの変更(コンテンツエリア最大化)

### DIFF
--- a/apps/frontend/components/layout/AppModal.vue
+++ b/apps/frontend/components/layout/AppModal.vue
@@ -1,7 +1,10 @@
 <template>
   <Teleport to="body">
     <div class="modal-overlay">
-      <div ref="modalTarget" class="modal-container">
+      <div
+        ref="modalTarget"
+        class="modal-container"
+      >
         <div class="modal-body">
           <slot />
         </div>

--- a/apps/frontend/components/organisms/PersonAddModal.vue
+++ b/apps/frontend/components/organisms/PersonAddModal.vue
@@ -1,6 +1,9 @@
 <template>
   <AppModal @close="closeModal">
-    <form class="person-form" @submit.prevent="submitForm">
+    <form
+      class="person-form"
+      @submit.prevent="submitForm"
+    >
       <div class="field-row">
         <FormField
           v-model="form.name"
@@ -53,7 +56,10 @@
     </form>
 
     <template #footer>
-      <AppButton variant="secondary" @click="closeModal">
+      <AppButton
+        variant="secondary"
+        @click="closeModal"
+      >
         キャンセル
       </AppButton>
       <AppButton
@@ -138,7 +144,8 @@ const submitForm = async (): Promise<void> => {
 
     // 親コンポーネントにデータを渡す
     emit('save', cleanedForm)
-  } finally {
+  }
+  finally {
     isLoading.value = false
   }
 }

--- a/apps/frontend/composables/useApi.ts
+++ b/apps/frontend/composables/useApi.ts
@@ -10,7 +10,7 @@ export type UseApiOptions = {
 
 export const useApi = async <T = unknown>(
   url: string,
-  options: UseApiOptions = {}
+  options: UseApiOptions = {},
 ): Promise<ApiResponse<T>> => {
   const { method = 'GET', body, headers = {} } = options
 
@@ -26,16 +26,17 @@ export const useApi = async <T = unknown>(
     }
 
     if (
-      body &&
-      (method === 'POST' || method === 'PUT' || method === 'DELETE')
+      body
+      && (method === 'POST' || method === 'PUT' || method === 'DELETE')
     ) {
-      requestOptions.body =
-        typeof body === 'string' ? body : JSON.stringify(body)
+      requestOptions.body
+        = typeof body === 'string' ? body : JSON.stringify(body)
     }
 
     const response = await fetch(url, requestOptions)
     return await response.json()
-  } catch (err) {
+  }
+  catch (err) {
     return {
       error: {
         statusCode: 500,

--- a/apps/frontend/composables/useValidation.ts
+++ b/apps/frontend/composables/useValidation.ts
@@ -116,7 +116,6 @@ export function usePersonValidation(form: PersonForm) {
     }
   }
 
-
   /**
    * 生年月日と没年月日の関係をバリデーション
    */
@@ -190,7 +189,6 @@ export function usePersonValidation(form: PersonForm) {
       validateField('birthPlace', newValue)
     }
   })
-
 
   return {
     errors,

--- a/apps/frontend/pages/components-demo.vue
+++ b/apps/frontend/pages/components-demo.vue
@@ -67,11 +67,19 @@
             <UserPlusIcon class="icon" />
             人物を追加
           </AppButton>
-          <AppButton variant="primary" :is-loading="true">
+          <AppButton
+            variant="primary"
+            :is-loading="true"
+          >
             <UserPlusIcon class="icon" />
             ローディング中
           </AppButton>
-          <AppButton variant="secondary" @click="clearForm"> クリア </AppButton>
+          <AppButton
+            variant="secondary"
+            @click="clearForm"
+          >
+            クリア
+          </AppButton>
         </div>
       </div>
     </section>
@@ -87,10 +95,18 @@
             label="検索"
             placeholder="名前で検索..."
           />
-          <AppButton variant="primary" @click="handleSearch"> 検索 </AppButton>
+          <AppButton
+            variant="primary"
+            @click="handleSearch"
+          >
+            検索
+          </AppButton>
         </div>
 
-        <div v-if="searchQuery" class="search-results">
+        <div
+          v-if="searchQuery"
+          class="search-results"
+        >
           <p>検索結果: "{{ searchQuery }}" に関する人物</p>
         </div>
       </div>
@@ -118,10 +134,16 @@
           </div>
 
           <div class="form-actions">
-            <AppButton variant="primary" @click="handleSaveRelationship">
+            <AppButton
+              variant="primary"
+              @click="handleSaveRelationship"
+            >
               関係を保存
             </AppButton>
-            <AppButton variant="danger" @click="handleDeleteRelationship">
+            <AppButton
+              variant="danger"
+              @click="handleDeleteRelationship"
+            >
               関係を削除
             </AppButton>
           </div>
@@ -182,7 +204,10 @@
           >
             検証実行
           </AppButton>
-          <AppButton variant="primary" :is-disabled="true">
+          <AppButton
+            variant="primary"
+            :is-disabled="true"
+          >
             無効なボタン
           </AppButton>
         </div>
@@ -195,21 +220,36 @@
       <div class="danger-actions">
         <p>重要なデータの削除など、取り返しのつかない操作の例：</p>
         <div class="danger-buttons">
-          <AppButton variant="danger" @click="handleDeletePerson">
+          <AppButton
+            variant="danger"
+            @click="handleDeletePerson"
+          >
             人物を削除
           </AppButton>
-          <AppButton variant="danger" @click="handleDeleteFamily">
+          <AppButton
+            variant="danger"
+            @click="handleDeleteFamily"
+          >
             家系図全体を削除
           </AppButton>
         </div>
 
-        <div v-if="showConfirmation" class="confirmation-dialog">
+        <div
+          v-if="showConfirmation"
+          class="confirmation-dialog"
+        >
           <p>この操作は取り消せません。本当に実行しますか？</p>
           <div class="confirmation-actions">
-            <AppButton variant="danger" @click="confirmAction">
+            <AppButton
+              variant="danger"
+              @click="confirmAction"
+            >
               はい、削除します
             </AppButton>
-            <AppButton variant="secondary" @click="cancelAction">
+            <AppButton
+              variant="secondary"
+              @click="cancelAction"
+            >
               キャンセル
             </AppButton>
           </div>
@@ -226,7 +266,10 @@
       </p>
 
       <div class="person-add-demo">
-        <AppButton variant="primary" @click="showPersonAddModal = true">
+        <AppButton
+          variant="primary"
+          @click="showPersonAddModal = true"
+        >
           <UserPlusIcon class="icon" />
           人物追加モーダルを開く
         </AppButton>
@@ -247,7 +290,10 @@
           </ul>
         </div>
 
-        <div v-if="savedPersonData" class="saved-data-display">
+        <div
+          v-if="savedPersonData"
+          class="saved-data-display"
+        >
           <h4>保存されたデータ:</h4>
           <pre>{{ JSON.stringify(savedPersonData, null, 2) }}</pre>
         </div>
@@ -301,7 +347,10 @@
       </div>
 
       <!-- 基本モーダル -->
-      <AppModal v-if="showBasicModal" @close="showBasicModal = false">
+      <AppModal
+        v-if="showBasicModal"
+        @close="showBasicModal = false"
+      >
         <p>これは基本的なモーダルです。</p>
         <p>ESCキーまたは背景をクリックして閉じることができます。</p>
         <p>
@@ -310,7 +359,10 @@
       </AppModal>
 
       <!-- 人物詳細風モーダル -->
-      <AppModal v-if="showPersonModal" @close="showPersonModal = false">
+      <AppModal
+        v-if="showPersonModal"
+        @close="showPersonModal = false"
+      >
         <div class="person-detail-content">
           <div class="person-info-grid">
             <div class="info-item">
@@ -348,22 +400,34 @@
       </AppModal>
 
       <!-- フッター付きモーダル -->
-      <AppModal v-if="showFooterModal" @close="showFooterModal = false">
+      <AppModal
+        v-if="showFooterModal"
+        @close="showFooterModal = false"
+      >
         <p>「山田太郎」を家系図から削除しますか？</p>
         <p><strong>※ この操作は取り消せません。</strong></p>
 
         <template #footer>
-          <AppButton variant="secondary" @click="showFooterModal = false">
+          <AppButton
+            variant="secondary"
+            @click="showFooterModal = false"
+          >
             キャンセル
           </AppButton>
-          <AppButton variant="danger" @click="confirmDelete">
+          <AppButton
+            variant="danger"
+            @click="confirmDelete"
+          >
             削除する
           </AppButton>
         </template>
       </AppModal>
 
       <!-- 長いコンテンツモーダル -->
-      <AppModal v-if="showNoOverlayModal" @close="showNoOverlayModal = false">
+      <AppModal
+        v-if="showNoOverlayModal"
+        @close="showNoOverlayModal = false"
+      >
         <p>フォーム入力機能を含むモーダルの例です。</p>
         <p>ESCキーまたは背景クリックで閉じることができます。</p>
         <p>必要に応じてフッターにアクションボタンを配置できます。</p>
@@ -392,7 +456,10 @@
           >
             閉じる
           </AppButton>
-          <AppButton :full-width="true" @click="saveModalForm">
+          <AppButton
+            :full-width="true"
+            @click="saveModalForm"
+          >
             保存
           </AppButton>
         </template>
@@ -557,11 +624,11 @@ const modalFormData = ref({
 // すべてのモーダル状態を監視してbodyスクロールを制御
 const isAnyModalOpen = computed(
   () =>
-    showBasicModal.value ||
-    showPersonModal.value ||
-    showFooterModal.value ||
-    showNoOverlayModal.value ||
-    showPersonAddModal.value
+    showBasicModal.value
+    || showPersonModal.value
+    || showFooterModal.value
+    || showNoOverlayModal.value
+    || showPersonAddModal.value,
 )
 
 useHead(() => ({
@@ -592,13 +659,13 @@ const hasErrors = computed(() => {
 
 // 性別の値をラベルに変換
 const getGenderLabel = (value: string): string => {
-  const option = genderOptions.find((opt) => opt.value === value)
+  const option = genderOptions.find(opt => opt.value === value)
   return option ? option.label : ''
 }
 
 // 関係性の値をラベルに変換
 const getRelationshipLabel = (value: string): string => {
-  const option = relationshipOptions.find((opt) => opt.value === value)
+  const option = relationshipOptions.find(opt => opt.value === value)
   return option ? option.label : ''
 }
 
@@ -606,7 +673,7 @@ const getRelationshipLabel = (value: string): string => {
 const handleAddPerson = async (): Promise<void> => {
   isSubmitting.value = true
   // 実際のAPIコールをシミュレート
-  await new Promise((resolve) => setTimeout(resolve, 2000))
+  await new Promise(resolve => setTimeout(resolve, 2000))
   isSubmitting.value = false
   alert(`人物「${personForm.value.name}」を追加しました`)
 }

--- a/apps/frontend/pages/index.vue
+++ b/apps/frontend/pages/index.vue
@@ -1,15 +1,5 @@
 <template>
   <div class="page-container">
-    <!-- ヘッダー -->
-    <header class="app-header">
-      <h1 class="app-title">
-        Family Tree App
-      </h1>
-      <button class="settings-btn">
-        設定
-      </button>
-    </header>
-
     <!-- メインコンテンツエリア -->
     <div class="content-area">
       <!-- 家系図表示エリア -->
@@ -92,39 +82,6 @@ const handleStartGuide = () => {
   background-color: var(--color-background);
 }
 
-/* ヘッダー */
-.app-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  padding: 1.6rem 1.6rem;
-  background-color: var(--color-background);
-  border-top: 3px solid var(--color-primary);
-  border-bottom: 1px solid var(--color-border);
-}
-
-.app-title {
-  margin: 0;
-  color: var(--color-primary);
-  font-size: 1.9rem;
-  font-weight: 600;
-}
-
-.settings-btn {
-  padding: 0.5rem 1.6rem;
-  background-color: var(--color-background);
-  color: var(--color-primary);
-  border: 1px solid var(--color-primary);
-  border-radius: 0.6rem;
-  cursor: pointer;
-  font-size: 1.6rem;
-}
-
-.settings-btn:hover {
-  background-color: var(--color-primary);
-  color: var(--color-background);
-}
-
 /* メインコンテンツエリア */
 .content-area {
   display: flex;
@@ -139,7 +96,7 @@ const handleStartGuide = () => {
   padding: 1.6rem;
   overflow: auto;
   /* 背景を画面の一番下まで拡張 */
-  min-height: calc(100vh - 95px); /* ヘッダー高さ分を引く */
+  min-height: 100vh;
 }
 
 .tree-container {
@@ -230,10 +187,6 @@ const handleStartGuide = () => {
 
 /* レスポンシブ対応 */
 @media (max-width: 768px) {
-  .app-header {
-    padding: 1rem;
-  }
-
   .content-area {
     flex-direction: column;
   }


### PR DESCRIPTION
## 概要
issue #69の要件を満たすため、以下の実装を行いました：
- ヘッダー要素を完全に削除し、コンテンツエリアを画面全体（100vh）に拡張
- ユーザーにとって家系図の表示領域が最大化され、視認性が向上
- モバイルファーストとミニマルデザインのトレンドに沿った実装

## 実装内容

### 追加・変更したファイル
- [apps/frontend/pages/index.vue](apps/frontend/pages/index.vue): ヘッダー要素を削除、CSSを調整してコンテンツエリアを100vhに拡張

### 技術的判断と根拠
- **選択した技術・手法**: テンプレートからヘッダーセクションを削除し、CSSのmin-height計算を修正
- **選択理由**: 
  - 固定ヘッダー（95px）がコンテンツ表示領域を制限していたため、削除により画面全体を活用可能に
  - flexboxレイアウトを活用し、.family-tree-areaがページ全体に自動拡張される設計
  - 既存のフローティングボタンはそのまま維持し、設定機能は別issueで検討
- **既存システムとの整合性**: 
  - 既存のEmptyStateとPersonCardコンポーネントは変更なしで動作
  - デザインシステムのCSS変数を継続使用
- **将来への考慮**: 
  - 設定機能へのアクセス方法は別issueで実装予定（フローティングボタンやキーボードショートカット）

## テスト結果

### 品質チェック結果
- Backend品質チェック: ✅ 通過（warnings: console.log使用のみ）
- Frontend品質チェック: ✅ 通過（ESLint自動修正後）
- Unit テスト: ✅ 通過
- Integration テスト: ⚠️ スキップ（環境変数ROOT_PATH未設定エラー - 既存の問題）

## 受け入れ基準チェックリスト

- [x] <header>要素が完全に削除されている
- [x] コンテンツエリアが画面全体（100vh）を使用している
- [x] フローティング追加ボタンが適切に表示・機能している
- [x] レスポンシブデザインが正常に動作している（768px未満でも問題なし）
- [x] CSS変数やデザインシステムとの整合性が保たれている
- [x] 既存のEmptyStateとPersonCardコンポーネントが正常に表示される
- [x] モバイル端末での表示が改善されている

Closes #69