### PR TITLE
test(#58): フロントエンドIntegrationテスト環境構築

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,30 +34,6 @@ services:
       - "${MYSQL_PORT}:3306"
     volumes:
       - ./docker/db/init.sql:/docker-entrypoint-initdb.d/init.sql
-
-  # テスト用データベース（profilesで制御）
-  test-db:
-    build:
-      context: .
-      dockerfile: docker/db/Dockerfile
-    environment:
-      - MYSQL_ROOT_PASSWORD=testpass
-      - MYSQL_DATABASE=family_tree_test
-      - MYSQL_USER=testuser
-      - MYSQL_PASSWORD=testpass
-      - TZ=Asia/Tokyo
-    env_file:
-      - .env.test
-    tmpfs:
-      - /var/lib/mysql # メモリ上での高速実行
-    healthcheck:
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1", "-ptestpass"]
-      interval: 2s
-      timeout: 3s
-      retries: 20
-      start_period: 5s
-    profiles: ["test"] # テストプロファイル指定
-
 networks:
   default:
     name: my-family-tree-shared


### PR DESCRIPTION
## Summary
- フロントエンドIntegrationテストの環境を構築
- バックエンドテスト実行時にmainのdbコンテナが停止される問題を解決
- test-backend.shをDocker Composeから直接docker runに変更し、専用ネットワークで分離

## 主な変更内容
- **scripts/test-backend.sh**: Docker Composeの代わりにdocker runを使用してtest-dbを起動
  - 専用ネットワーク（test-network）を作成してmainのdbと分離
  - 軽量なMySQL設定（256MB制限）でメモリ使用量を削減
  - .env.testで設定を一元管理
  - 色付き出力対応（-tオプション）
  - クリーンアップ処理をtrapで確実に実行
- **docker-compose.yml**: test-dbサービスを削除（docker runで直接管理）
- **.env.test**: テスト用の環境変数を定義

## 解決した問題
- worktree環境でバックエンドテスト実行時にmainのdbコンテナが停止される問題（Exit 137 = SIGKILL）
- OOM Killerによるメモリ不足問題を、軽量設定と専用ネットワーク分離で解決
- 他のworktreeに影響を与えずにテストを実行可能に

## Test plan
- [ ] `npm run test:backend`を実行してバックエンドテストが成功すること
- [ ] テスト実行中・実行後もmainのdbコンテナが稼働し続けること
- [ ] テスト実行後にtest-db、test-networkが正しくクリーンアップされること
- [ ] 複数worktreeで同時にテストを実行しても問題ないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)