### PR TITLE
Honoフレームワーク導入準備（依存関係・型定義）

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -28,8 +28,10 @@
     "schema": "./database/schema.prisma"
   },
   "dependencies": {
+    "@hono/zod-validator": "0.7.3",
     "@prisma/client": "5.22.0",
     "express": "5.1.0",
+    "hono": "4.9.9",
     "zod": "4.1.11"
   },
   "devDependencies": {

--- a/docs/02_technical/07_package_json_design.md
+++ b/docs/02_technical/07_package_json_design.md
@@ -423,18 +423,34 @@ family-tree-app/
 - **バージョン統一**: prismaとclientの同期必須
 - **データベース設計書整合性**: docs/02_technical/02_database_design.mdとの一貫性
 
-**環境変数・バリデーション**
+**Webフレームワーク（段階的移行）**
 
 ```json
-"dotenv": "16.4.5",
-"zod": "3.23.8"
+"hono": "4.9.9",
+"@hono/zod-validator": "0.7.3"
 ```
 
-- **dotenv**: .envファイル読み込み（Docker環境での設定管理）
+- **Hono導入理由**:
+  - **型安全性**: 完全なTypeScript型推論（エンドツーエンド）
+  - **パフォーマンス**: 軽量で高速な実装
+  - **開発体験**: モダンなAPI設計、Web標準準拠
+  - **段階的移行**: 既存Express環境と並行運用可能
+- **@hono/zod-validator**: HonoとZodの統合ライブラリ（バリデーション処理の型安全化）
+- **移行戦略**: Express 5.xから段階的にHonoへ移行予定
+
+**バリデーション**
+
+```json
+"zod": "4.1.11"
+```
+
 - **zod選定理由**:
   - **vs Joi**: TypeScript統合、型推論優位
   - **vs Yup**: パフォーマンス、軽量性
   - **用途**: APIリクエスト検証、環境変数検証
+- **v4.1.11採用理由**:
+  - @hono/zod-validator 0.7.3の要件（zod ^3.25.0 || ^4.0.0）を満たす
+  - 最新の型安全性改善と機能追加
 
 #### **開発依存関係（devDependencies）**
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,9 +31,11 @@
       "name": "@family-tree-app/backend",
       "version": "0.1.0",
       "dependencies": {
+        "@hono/zod-validator": "0.7.3",
         "@prisma/client": "5.22.0",
         "express": "5.1.0",
-        "zod": "3.23.8"
+        "hono": "4.9.9",
+        "zod": "4.1.11"
       },
       "devDependencies": {
         "@types/express": "5.0.3",
@@ -69,6 +71,13 @@
         "npm-run-all": "4.1.5",
         "vitest": "3.2.4",
         "vue-tsc": "2.1.6"
+      }
+    },
+    "apps/shared": {
+      "name": "@family-tree-app/shared",
+      "version": "0.1.0",
+      "dependencies": {
+        "zod": "4.1.11"
       }
     },
     "node_modules/@antfu/install-pkg": {
@@ -2100,6 +2109,10 @@
       "resolved": "apps/frontend",
       "link": true
     },
+    "node_modules/@family-tree-app/shared": {
+      "resolved": "apps/shared",
+      "link": true
+    },
     "node_modules/@heroicons/vue": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/@heroicons/vue/-/vue-2.2.0.tgz",
@@ -2107,6 +2120,16 @@
       "license": "MIT",
       "peerDependencies": {
         "vue": ">= 3"
+      }
+    },
+    "node_modules/@hono/zod-validator": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@hono/zod-validator/-/zod-validator-0.7.3.tgz",
+      "integrity": "sha512-uYGdgVib3RlGD698WR5dVM0zB3UuPY5vHKXffGUbUh7r4xY+mFIhF3/v4AcQVLrU5CQdBso8BJr4wuVoCrjTuQ==",
+      "license": "MIT",
+      "peerDependencies": {
+        "hono": ">=3.9.0",
+        "zod": "^3.25.0 || ^4.0.0"
       }
     },
     "node_modules/@humanfs/core": {
@@ -10299,6 +10322,15 @@
         "he": "bin/he"
       }
     },
+    "node_modules/hono": {
+      "version": "4.9.9",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.9.9.tgz",
+      "integrity": "sha512-Hxw4wT6zjJGZJdkJzAx9PyBdf7ZpxaTSA0NfxqjLghwMrLBX8p33hJBzoETRakF3UJu6OdNQBZAlNSkGqKFukw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
     "node_modules/hookable": {
       "version": "5.5.3",
       "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
@@ -17554,9 +17586,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "3.23.8",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.23.8.tgz",
-      "integrity": "sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==",
+      "version": "4.1.11",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.1.11.tgz",
+      "integrity": "sha512-WPsqwxITS2tzx1bzhIKsEs19ABD5vmCVa4xBo2tq/SrV4RNZtfws1EnCWQXM6yh8bD08a1idvkB5MZSBiZsjwg==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"


### PR DESCRIPTION
## 概要
issue #79の要件を満たすため、Honoフレームワークの段階的導入準備として以下の実装を行いました：
- Honoフレームワークとzodバリデーターの依存関係追加により、将来的な型安全なAPI開発基盤を整備
- 既存Express環境を維持したまま並行運用可能な構成を実現
- package.json設計書への詳細なドキュメント追加により、技術選定理由と移行戦略を明確化

## 実装内容

### 追加・変更したファイル
- [apps/backend/package.json](apps/backend/package.json): Hono関連依存関係を追加（hono 4.9.9、@hono/zod-validator 0.7.3）、zod 4.1.11へアップグレード
- [package-lock.json](package-lock.json): 依存関係のロックファイル更新
- [docs/02_technical/07_package_json_design.md](docs/02_technical/07_package_json_design.md): Hono導入理由と技術的メリットを記載

### 技術的判断と根拠
- **選択した技術・手法**: Hono 4.9.9とZod 4.1.11の最新安定版
- **選択理由**: 
  - Honoは完全なTypeScript型推論を提供し、エンドツーエンドの型安全性を実現
  - @hono/zod-validatorによりバリデーション処理の型安全化が可能
  - zod 4.1.11は@hono/zod-validator 0.7.3の要件（zod ^3.25.0 || ^4.0.0）を満たし、最新の型安全性改善を提供
- **既存システムとの整合性**: 既存Express環境と並行運用可能な段階的移行アプローチを採用
- **将来への考慮**: 段階的にExpressからHonoへ移行する戦略を文書化し、後続の実装を容易に

## テスト結果

### 品質チェック結果
- Backend品質チェック: ✅ 通過（型チェック、lint、単体テスト全て成功）
- Unit テスト: ✅ 通過（69テスト全て成功）
- Integration テスト: ✅ 通過（3テスト全て成功）

## 受け入れ基準チェックリスト

- [x] `package.json`に`hono`と`@hono/zod-validator`が追加されている
- [x] 既存のExpress依存関係は維持されている（段階的移行のため）
- [x] `npm install`が正常に実行できる
- [x] TypeScriptの型チェックが通る（`npm run type-check:backend`）
- [x] 既存のテストが全て通る（`npm run test:backend`）

Closes #79