### PR TITLE
Hono版app.ts実装（基本設定・ミドルウェア）

### DIFF
--- a/apps/backend/app.hono.ts
+++ b/apps/backend/app.hono.ts
@@ -1,0 +1,88 @@
+import { AppError } from '@/errors/AppError.js'
+import { Hono } from 'hono'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library.js'
+import { ZodError } from 'zod'
+
+type Env = {
+  Variables: Record<string, unknown>
+}
+
+function isPrismaError(error: unknown): error is PrismaClientKnownRequestError {
+  return error instanceof PrismaClientKnownRequestError
+}
+
+export function createHonoApp(): Hono<Env> {
+  const app = new Hono<Env>()
+
+  // グローバルエラーハンドラー
+  app.onError((error, c) => {
+    console.error('Error caught:', error)
+
+    // ZodError処理
+    if (error instanceof ZodError) {
+      const details = error.issues.map((e) => ({
+        field: e.path.join('.'),
+        code: e.message,
+      }))
+
+      return c.json(
+        {
+          error: {
+            statusCode: 400,
+            errorCode: 'VALIDATION_ERROR',
+            details,
+          },
+        },
+        400
+      )
+    }
+
+    // PrismaError処理
+    if (isPrismaError(error)) {
+      console.error('Database error:', error)
+
+      return c.json(
+        {
+          error: {
+            statusCode: 500,
+            errorCode: 'DATABASE_ERROR',
+            details: [],
+          },
+        },
+        500
+      )
+    }
+
+    // AppError処理
+    if (error instanceof AppError) {
+      console.error('Application error:', error)
+
+      return c.json(
+        {
+          error: {
+            statusCode: error.statusCode,
+            errorCode: error.errorCode,
+            details: [],
+          },
+        },
+        error.statusCode
+      )
+    }
+
+    // 予期しないエラー処理
+    console.error('Unexpected error:', error)
+
+    return c.json(
+      {
+        error: {
+          statusCode: 500,
+          errorCode: 'UNKNOWN_ERROR',
+          details: [],
+        },
+      },
+      500
+    )
+  })
+
+  return app
+}

--- a/apps/backend/app.hono.ts
+++ b/apps/backend/app.hono.ts
@@ -1,6 +1,7 @@
 import { AppError } from '@/errors/AppError.js'
-import { Hono } from 'hono'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library.js'
+import { Hono } from 'hono'
+import type { Context } from 'hono'
 import { ZodError } from 'zod'
 
 type Env = {
@@ -65,7 +66,7 @@ export function createHonoApp(): Hono<Env> {
             details: [],
           },
         },
-        error.statusCode
+        error.statusCode as Parameters<Context['json']>[1]
       )
     }
 

--- a/apps/backend/tests/unit/app.hono.test.ts
+++ b/apps/backend/tests/unit/app.hono.test.ts
@@ -1,8 +1,8 @@
-import { AppError } from '@/errors/AppError.js'
 import { createHonoApp } from '@/app.hono.js'
+import { AppError } from '@/errors/AppError.js'
 import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library.js'
-import { ZodError, z } from 'zod'
 import { describe, expect, it } from 'vitest'
+import { z } from 'zod'
 
 describe('createHonoApp', () => {
   it('Honoアプリケーションインスタンスを返すこと', () => {
@@ -16,28 +16,33 @@ describe('createHonoApp', () => {
       const app = createHonoApp()
 
       // ZodErrorをスローするルートを追加
-      app.get('/test-zod-error', () => {
+      app.get('/test-zod-error', (c) => {
         const schema = z.object({ name: z.string() })
         schema.parse({ name: 123 }) // 意図的にエラーを発生させる
+        return c.json({ ok: true })
       })
 
       const res = await app.request('/test-zod-error')
       const json = (await res.json()) as {
-        error: { statusCode: number; errorCode: string; details: Array<{ field: string; code: string }> }
+        error: {
+          statusCode: number
+          errorCode: string
+          details: Array<{ field: string; code: string }>
+        }
       }
 
       expect(res.status).toBe(400)
       expect(json.error.statusCode).toBe(400)
       expect(json.error.errorCode).toBe('VALIDATION_ERROR')
       expect(json.error.details).toHaveLength(1)
-      expect(json.error.details[0].field).toBe('name')
+      expect(json.error.details[0]?.field).toBe('name')
     })
 
     it('PrismaClientKnownRequestErrorを500エラーとして処理すること', async () => {
       const app = createHonoApp()
 
       // PrismaErrorをスローするルートを追加
-      app.get('/test-prisma-error', () => {
+      app.get('/test-prisma-error', (_c) => {
         throw new PrismaClientKnownRequestError('Database error', {
           code: 'P2002',
           clientVersion: '5.0.0',
@@ -59,7 +64,7 @@ describe('createHonoApp', () => {
       const app = createHonoApp()
 
       // AppErrorをスローするルートを追加
-      app.get('/test-app-error', () => {
+      app.get('/test-app-error', (_c) => {
         throw new AppError('リソースが見つかりません', 404, 'NOT_FOUND')
       })
 
@@ -78,7 +83,7 @@ describe('createHonoApp', () => {
       const app = createHonoApp()
 
       // 一般的なエラーをスローするルートを追加
-      app.get('/test-unknown-error', () => {
+      app.get('/test-unknown-error', (_c) => {
         throw new Error('予期しないエラー')
       })
 

--- a/apps/backend/tests/unit/app.hono.test.ts
+++ b/apps/backend/tests/unit/app.hono.test.ts
@@ -1,0 +1,96 @@
+import { AppError } from '@/errors/AppError.js'
+import { createHonoApp } from '@/app.hono.js'
+import { PrismaClientKnownRequestError } from '@prisma/client/runtime/library.js'
+import { ZodError, z } from 'zod'
+import { describe, expect, it } from 'vitest'
+
+describe('createHonoApp', () => {
+  it('Honoアプリケーションインスタンスを返すこと', () => {
+    const app = createHonoApp()
+    expect(app).toBeDefined()
+    expect(typeof app.fetch).toBe('function')
+  })
+
+  describe('エラーハンドリング', () => {
+    it('ZodErrorを400エラーとして処理すること', async () => {
+      const app = createHonoApp()
+
+      // ZodErrorをスローするルートを追加
+      app.get('/test-zod-error', () => {
+        const schema = z.object({ name: z.string() })
+        schema.parse({ name: 123 }) // 意図的にエラーを発生させる
+      })
+
+      const res = await app.request('/test-zod-error')
+      const json = (await res.json()) as {
+        error: { statusCode: number; errorCode: string; details: Array<{ field: string; code: string }> }
+      }
+
+      expect(res.status).toBe(400)
+      expect(json.error.statusCode).toBe(400)
+      expect(json.error.errorCode).toBe('VALIDATION_ERROR')
+      expect(json.error.details).toHaveLength(1)
+      expect(json.error.details[0].field).toBe('name')
+    })
+
+    it('PrismaClientKnownRequestErrorを500エラーとして処理すること', async () => {
+      const app = createHonoApp()
+
+      // PrismaErrorをスローするルートを追加
+      app.get('/test-prisma-error', () => {
+        throw new PrismaClientKnownRequestError('Database error', {
+          code: 'P2002',
+          clientVersion: '5.0.0',
+        })
+      })
+
+      const res = await app.request('/test-prisma-error')
+      const json = (await res.json()) as {
+        error: { statusCode: number; errorCode: string; details: unknown[] }
+      }
+
+      expect(res.status).toBe(500)
+      expect(json.error.statusCode).toBe(500)
+      expect(json.error.errorCode).toBe('DATABASE_ERROR')
+      expect(json.error.details).toEqual([])
+    })
+
+    it('AppErrorを適切なステータスコードで処理すること', async () => {
+      const app = createHonoApp()
+
+      // AppErrorをスローするルートを追加
+      app.get('/test-app-error', () => {
+        throw new AppError('リソースが見つかりません', 404, 'NOT_FOUND')
+      })
+
+      const res = await app.request('/test-app-error')
+      const json = (await res.json()) as {
+        error: { statusCode: number; errorCode: string; details: unknown[] }
+      }
+
+      expect(res.status).toBe(404)
+      expect(json.error.statusCode).toBe(404)
+      expect(json.error.errorCode).toBe('NOT_FOUND')
+      expect(json.error.details).toEqual([])
+    })
+
+    it('予期しないエラーを500エラーとして処理すること', async () => {
+      const app = createHonoApp()
+
+      // 一般的なエラーをスローするルートを追加
+      app.get('/test-unknown-error', () => {
+        throw new Error('予期しないエラー')
+      })
+
+      const res = await app.request('/test-unknown-error')
+      const json = (await res.json()) as {
+        error: { statusCode: number; errorCode: string; details: unknown[] }
+      }
+
+      expect(res.status).toBe(500)
+      expect(json.error.statusCode).toBe(500)
+      expect(json.error.errorCode).toBe('UNKNOWN_ERROR')
+      expect(json.error.details).toEqual([])
+    })
+  })
+})

--- a/docs/02_technical/01_architecture.md
+++ b/docs/02_technical/01_architecture.md
@@ -126,6 +126,48 @@ export const create = async (data: CreatePersonData) => {
 }
 ```
 
+### 4.3 Honoフレームワーク移行戦略
+
+#### 段階的移行アプローチ
+
+Express.jsからHonoへの段階的移行を実施中です。
+
+**移行戦略の理由**
+
+- **型安全性の向上**: Honoはエンドツーエンドの型推論を提供
+- **パフォーマンス**: 軽量で高速な実装
+- **開発体験**: モダンなAPI設計、Web標準準拠
+- **並行運用**: 既存Express環境と共存可能
+
+#### Hono版app.ts（app.hono.ts）
+
+```typescript
+// apps/backend/app.hono.ts
+export function createHonoApp(): Hono<Env> {
+  const app = new Hono<Env>()
+
+  // グローバルエラーハンドラー
+  app.onError((error, c) => {
+    // ZodError、PrismaError、AppError、予期しないエラーを処理
+    // Express版と同じエラーレスポンス形式を維持
+  })
+
+  return app
+}
+```
+
+**主要機能**
+
+- **エラーハンドリング**: ZodError、PrismaClientKnownRequestError、AppError、予期しないエラーの統一処理
+- **レスポンス形式**: Express版との互換性維持
+- **型安全性**: TypeScript型推論によるコンパイル時エラー検出
+
+**並行運用の利点**
+
+- 既存Express版（`app.ts`）は影響を受けない
+- ルートごとに段階的に移行可能
+- ロールバックが容易
+
 ## 5. Docker 構成
 
 ### 5.1 マルチコンテナ戦略
@@ -133,7 +175,7 @@ export const create = async (data: CreatePersonData) => {
 ```yaml
 # docker-compose.yml
 services:
-  apps: # Node.js（Nuxt + Express）統合コンテナ
+  apps: # Node.js（Nuxt + Express + Hono）統合コンテナ
   db: # MySQL
 ```
 


### PR DESCRIPTION
## 概要
issue #80の要件を満たすため、Hono版のアプリケーション設定ファイル（app.hono.ts）を実装しました。

これにより、Express.jsからHonoへの段階的移行の基盤を構築し、型安全性とパフォーマンスの向上を実現します。

## 実装内容

### 追加・変更したファイル
- [apps/backend/app.hono.ts](apps/backend/app.hono.ts): Honoアプリケーション設定の新規実装
  - `createHonoApp()`関数によるHonoインスタンス作成
  - グローバルエラーハンドラーの統合（Express版と同等の機能を維持）
- [apps/backend/tests/unit/app.hono.test.ts](apps/backend/tests/unit/app.hono.test.ts): app.hono.tsのテストケース追加
  - エラーハンドリング機能の検証（ZodError、PrismaError、AppError、予期しないエラー）
- [docs/02_technical/01_architecture.md](docs/02_technical/01_architecture.md): アーキテクチャ設計書の更新
  - Hono移行戦略の説明追加

### 技術的判断と根拠
- **選択した技術・手法**: Honoフレームワークによる新規アプリケーション設定ファイル（app.hono.ts）
- **選択理由**: 
  - Express版（app.ts）と並行運用可能な設計により、段階的な移行を実現
  - Honoのエンドツーエンド型推論により、型安全性を大幅に向上
  - 軽量で高速なHono実装によりパフォーマンス改善を期待
- **既存システムとの整合性**: 
  - Express版のエラーレスポンス形式を維持し、フロントエンドとの互換性を確保
  - 既存のエラークラス（AppError、PrismaClientKnownRequestError）を再利用
- **将来への考慮**: 
  - ルートごとに段階的にHonoへ移行可能
  - ロールバックが容易な設計

## テスト結果

### 品質チェック結果
- Backend品質チェック: ✅ 通過
- Backend Unit テスト: ✅ 通過（74 tests passed）
- TypeScript型チェック: ✅ 通過
- ESLint: ✅ 通過（warningのみ、console.log使用は許容範囲内）

## 受け入れ基準チェックリスト

- [x] `app.hono.ts`が作成され、Honoアプリケーションを返す`createHonoApp()`関数を実装
- [x] JSON parserが設定されている（Hono標準機能により自動的に処理）
- [x] エラーハンドリングが統合されている（Hono形式）
- [x] TypeScriptの型チェックが通る
- [x] 既存の`app.ts`（Express版）は影響を受けていない

Closes #80